### PR TITLE
feat: implement event status with update and filtering

### DIFF
--- a/Data/Entities/EventEntity.cs
+++ b/Data/Entities/EventEntity.cs
@@ -1,4 +1,6 @@
-﻿namespace Data.Entities;
+﻿using Domain.Models;
+
+namespace Data.Entities;
 
 public class EventEntity
 {
@@ -10,5 +12,7 @@ public class EventEntity
     public DateTime? EndDateTime { get; set; }
     public string Location { get; set; } = null!;
     public string Description { get; set; } = null!;
-   
+    public decimal Price { get; set; }
+    public EventStatus Status { get; set; }
+
 }

--- a/Data/Migrations/20250508085834_AddEventStatusToEvent.Designer.cs
+++ b/Data/Migrations/20250508085834_AddEventStatusToEvent.Designer.cs
@@ -4,6 +4,7 @@ using Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Data.Migrations
 {
     [DbContext(typeof(EventDbContext))]
-    partial class EventDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250508085834_AddEventStatusToEvent")]
+    partial class AddEventStatusToEvent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20250508085834_AddEventStatusToEvent.cs
+++ b/Data/Migrations/20250508085834_AddEventStatusToEvent.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEventStatusToEvent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Price",
+                table: "Events",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "Events",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Price",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Events");
+        }
+    }
+}

--- a/Domain/Models/CreateEventFormData.cs
+++ b/Domain/Models/CreateEventFormData.cs
@@ -20,4 +20,6 @@ public class CreateEventFormData
     public string Location { get; set; } = null!;
 
     public string Description { get; set; } = null!;
+    public decimal Price { get; set; } 
+
 }

--- a/Domain/Models/Event.cs
+++ b/Domain/Models/Event.cs
@@ -10,4 +10,7 @@ public class Event
     public DateTime? EndDateTime { get; set; }
     public string Location { get; set; } = null!;
     public string Description { get; set; } = null!;
+    public decimal Price { get; set; }
+    public EventStatus Status { get; set; }
+
 }

--- a/Domain/Models/EventResponseFormData.cs
+++ b/Domain/Models/EventResponseFormData.cs
@@ -9,4 +9,6 @@ public class EventResponseFormData
     public DateTime StartDateTime { get; set; }
     public string Location { get; set; } = null!;
     public string Description { get; set; } = null!;
+    public decimal Price { get; set; }
+    public EventStatus Status { get; set; }
 }

--- a/Domain/Models/EventStatus.cs
+++ b/Domain/Models/EventStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace Domain.Models;
+
+public enum EventStatus
+{
+    Draft = 0,
+    Active = 1,
+    Past = 2,
+}

--- a/Domain/Models/UpdateEventFormData.cs
+++ b/Domain/Models/UpdateEventFormData.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
+﻿
 namespace Domain.Models;
 
 public class UpdateEventFormData
@@ -11,4 +10,9 @@ public class UpdateEventFormData
     public DateTime? EndDateTime { get; set; }
     public string Location { get; set; } = null!;
     public string Description { get; set; } = null!;
+    public decimal Price { get; set; }
+    public EventStatus Status { get; set; }
+
+
+
 }

--- a/EventService.Api/Program.cs
+++ b/EventService.Api/Program.cs
@@ -2,13 +2,19 @@ using Business.Services;
 using Data.Context;
 using Data.Repositories;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<EventDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("LocalDb")));
 
-builder.Services.AddControllers();
+builder.Services
+    .AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddScoped<IEventService, EventsService>();

--- a/EventService.Api/appsettings.json
+++ b/EventService.Api/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "LocalDb": "Data Source=(LocalDB)\\MSSQLLocalDB;AttachDbFilename=C:\\Projects\\VentixeBackend2\\ventixe_backend\\src\\EventServiceProvider\\Data\\EventService_database.mdf;Integrated Security=True;Connect Timeout=30"
+    "LocalDb": "Data Source=(LocalDB)\\MSSQLLocalDB;AttachDbFilename=C:\\Users\\chris\\OneDrive\\Skrivbord\\EventService\\Data\\LocalDb_database.mdf;Integrated Security=True;Connect Timeout=30"
   }
 }
 


### PR DESCRIPTION
 New enum EventStatus (Draft, Active, Past)

 Support for setting Status in both CreateEventFormData and UpdateEventFormData

 Mapping of Status through the generic MapTo<T>() extension

 API filtering with GET /api/events?status=Active|Draft|Past

 Status is now serialized as string (e.g., "Active") in API responses

 Update flow supports changing the status of existing events

A new column Status was added to the Events table via EF Core migration

Default enum-to-int mapping used (0 = Draft, etc.)

JSON serialization updated to output enum names instead of numbers

